### PR TITLE
FIX seeder.service no load icon

### DIFF
--- a/ChilyAPI/src/modules/seeders/seeders.service.ts
+++ b/ChilyAPI/src/modules/seeders/seeders.service.ts
@@ -37,6 +37,7 @@ export class SeedersService implements OnModuleInit{
             for (const name of categoryNameSet) {
               const newCategory = new Category();
               newCategory.name = String(name);
+              newCategory.icon = "https://example.com/" + String(name).toLowerCase() + ".jpg";
               const savedCategory = await manager.save(newCategory);
               categoryEntity.push(savedCategory);
             }


### PR DESCRIPTION
FIX error when you deploy, the seeders try to create categories without icon